### PR TITLE
Replace qbsolv with tabu search

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This repository contains python code to run the Q-score (Max-Cut and Max-Clique) benchmark on the following solver backends:
 
 - D-Wave QPU device, the `Advantage_system4.1` ~~and `DW_2000Q_6`~~ QPU system. (The `DW_2000Q_6` device no longer available.)
-- D-Wave classical solvers, its `Simulated Annealing` and `qbsolv` solver
+- D-Wave classical solvers, its `Simulated Annealing` and ~~`qbsolv`~~ `Tabu` solver. (The `qbsolv` package is deprecated, but remains available in previous version.)
 - D-Wave hybrid solver.
 - Gate-based hardware using QAOA on QuantumInspire and IBM hardware or simulators.
 - Gaussian Boson Sampling, a form of photonic quantum computing, both simulated an using the 12-mode Quandela QPU.   
@@ -71,7 +71,7 @@ python -m pip install -r requirements.txt
 ```
 
 ### Set up D-Wave configuration
-To use the quantum annealing, simulated annealing, qbsolv or hybrid solver, we assume the reader has created a D-Wave Leap account and configured access to D-Wave's solvers correctly. To make an account, please visit the [website of D-wave](https://cloud.dwavesys.com/leap/login/?next=/leap/). To configure access to the solvers, please visit [these instructions](https://docs.ocean.dwavesys.com/en/stable/overview/sapi.html).
+To use the quantum annealing or hybrid solvers we assume the reader has created a D-Wave Leap account and configured access to D-Wave's solvers correctly. To make an account, please visit the [website of D-wave](https://cloud.dwavesys.com/leap/login/?next=/leap/). To configure access to the solvers, please visit [these instructions](https://docs.ocean.dwavesys.com/en/stable/overview/sapi.html).
 
 Example usage for the `Advantage_system4.1` QPU solver:
 

--- a/calculate_qscore.py
+++ b/calculate_qscore.py
@@ -71,7 +71,6 @@ def calculate_qscore(
         result, times = [], []
         exact_results = []
         for i in range(nb_instances_per_size):
-            print(f"START INSTANCE {i}")
             objective_result, _, time, G = main(
                 problem_type=problem_type,
                 size=size,
@@ -110,15 +109,15 @@ def calculate_qscore(
 
 if __name__ == "__main__":
     # Input arguments
-    _NB_INSTANCES_PER_SIZE = 10
-    _SIZE_RANGE = list(range(5, 150, 5))
-    FILE_NAME = "Adv_few_instances.json"
-    INCLUDE_EXACT_RESULTS = True
-    PROBLEM_TYPE = "max-clique"
+    _NB_INSTANCES_PER_SIZE = 1
+    _SIZE_RANGE = list(range(90000,20000, 1000))
+    FILE_NAME = "tabu.json"
+    INCLUDE_EXACT_RESULTS = False
+    PROBLEM_TYPE = "max-cut"
     TIMEOUT = 60
-    SOLVER = "Advantage_system4.1"
-    _SEED = 1012134
-    NUM_READS = 1024
+    SOLVER = "tabu"
+    _SEED = 101200
+    NUM_READS = None
     PROVIDER = None
     BACKEND = None
 

--- a/evaluate.py
+++ b/evaluate.py
@@ -15,7 +15,7 @@ from run.run_hybrid import run_hybrid
 from run.run_photonic_simulated import run_photonic_simulated
 from run.run_photonic_quandela import run_photonic_quandela
 from run.run_QAOA import run_QAOA
-from run.run_qbsolv import run_qbsolv
+from run.run_tabu import run_tabu
 from run.run_SA import run_SA
 from utils.max_clique import calculate_beta_max_clique, create_qubo_max_clique
 from utils.max_cut import calculate_beta_max_cut, create_qubo_max_cut
@@ -93,7 +93,7 @@ def parse_args() -> argparse.Namespace:
         choices=[
             "Advantage_system4.1",
             "hybrid",
-            "qbsolv",
+            "tabu",
             "Simulated_Annealing",
             "Photonic_Simulation",
             "Photonic_quandela",
@@ -201,9 +201,9 @@ def main(
             start_time = time.time()
             objective_result = run_SA(Q, size, num_reads, timeout)
             end_time = time.time()
-        elif solver == "qbsolv":
+        elif solver == "tabu":
             start_time = time.time()
-            objective_result = run_qbsolv(Q, size, timeout)
+            objective_result = run_tabu(Q, size, timeout)
             end_time = time.time()
         else:
             raise NotImplementedError(f"Provided Solver {solver} is not implemented")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,31 +1,10 @@
-# generic dependencies
 numpy==1.22.1
 networkx==2.8.8
-matplotlib==3.5.2
-
-# d-wave dependencies
-dwave-cloud-client==0.9.3
-dwave-greedy==0.2.2
-dwave-hybrid==0.6.5
-dwave-inspector==0.2.9
-dwave-neal==0.5.9
-dwave-networkx==0.8.11
-dwave-ocean-sdk==4.4.0
-dwave-preprocessing==0.3.2
-dwave-qbsolv==0.3.4
-dwave-system==1.12.0
-dwave-tabu==0.4.3
-dwavebinarycsp==0.1.4
-pydantic==1.10.4
-
-# photonic dependencies
+dwave-ocean-sdk==6.7.1
 strawberryfields==0.23.0
-perceval-quandela==0.8.1
-python-dotenv==0.21.0
-
-# qaoa dependencies
+matplotlib==3.5.2
 qiskit[optimization]==0.39.4
 quantuminspire==2.2.1
-
-# testing dependencies
+python-dotenv==0.21.0
 pytest==7.2.1
+perceval-quandela==0.8.1

--- a/run/run_tabu.py
+++ b/run/run_tabu.py
@@ -1,18 +1,17 @@
 """
-Run a Q-score instance on the D-Wave qbsolv solver.
+Run a Q-score instance using the D-Wave Tabu solver.
 """
-
 import time
 from collections import defaultdict
 from typing import Optional
 
 import numpy as np
-from dwave_qbsolv import QBSolv
+from tabu import TabuSampler
 
 
-def run_qbsolv(Q: defaultdict(int), size: int, timeout: Optional[int] = None) -> float:
+def run_tabu(Q: defaultdict(int), size: int, timeout: Optional[int] = None) -> float:
     """
-    Function that solves a Q-score instance on the D-Wave qbsolv solver.
+    Function that solves a Q-score instance on the D-Wave tabu solver.
 
     Args:
         Q: QUBO-formulation of Q-score instance.
@@ -25,7 +24,7 @@ def run_qbsolv(Q: defaultdict(int), size: int, timeout: Optional[int] = None) ->
     """
     start = time.time()
 
-    sampler = QBSolv()
+    sampler = TabuSampler()
     sampleset = sampler.sample_qubo(Q, label=f"Problem-{size:2d}")
 
     objective_result = -sampleset.first.energy

--- a/test/test_evaluate.py
+++ b/test/test_evaluate.py
@@ -11,7 +11,7 @@ from evaluate import main
     [
         "Advantage_system4.1",
         "hybrid",
-        "qbsolv",
+        "tabu",
         "Simulated_Annealing",
         "QAOA",
     ],
@@ -25,7 +25,7 @@ def test_evaluate_main_max_cut(solver):
     [
         "Advantage_system4.1",
         "hybrid",
-        "qbsolv",
+        "tabu",
         "Simulated_Annealing",
         "Photonic_Simulation",
         "Photonic_quandela",

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -10,8 +10,8 @@ from run.run_hybrid import run_hybrid
 from run.run_photonic_quandela import run_photonic_quandela
 from run.run_photonic_simulated import run_photonic_simulated
 from run.run_QAOA import run_QAOA
-from run.run_qbsolv import run_qbsolv
 from run.run_SA import run_SA
+from run.run_tabu import run_tabu
 from utils.max_cut import create_qubo_max_cut
 
 size, timeout = 4, None
@@ -23,8 +23,8 @@ def test_dwave_qpu_advantage():
     run_dwave_qpu(Q, size, solver="Advantage_system4.1", num_reads=1000, timeout=None)
 
 
-def test_qbsolv():
-    run_qbsolv(Q, size, timeout=None)
+def test_tabu():
+    run_tabu(Q, size, timeout=None)
 
 
 def test_SA():


### PR DESCRIPTION
Qbsolv is deprecated as of the end of 2021 and hence will be replaced by the dwave-tabu solver.